### PR TITLE
Add uv Python package manager to Docker image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -80,4 +80,12 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && \
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+# Add uv to PATH for this build
+ENV PATH="/home/node/.local/bin:$PATH"
+
 CMD ["claude"]


### PR DESCRIPTION
Install uv from Astral for faster Python package management and add it to PATH in both shell configs and as an ENV var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)