### PR TITLE
set default editor to vim

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -64,8 +64,8 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 ENV SHELL=/bin/zsh
 
 # Set the default editor and visual
-ENV EDITOR=nano
-ENV VISUAL=nano
+ENV EDITOR=vim
+ENV VISUAL=vim
 
 # Default powerline10k theme
 ARG ZSH_IN_DOCKER_VERSION=1.2.0


### PR DESCRIPTION
The main reason this matters is within claude-code ctrl+g allows editing of larger prompts in vim mode. I prefer vim, but if nano is preferred as a default we can add -e EDITOR=vim to the invocation