### PR TITLE
enh: bind mount original repo when running in a git worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When running in a git worktree, `yolo` can detect and optionally bind mount the 
 
 - `--worktree=ask` (default): Prompts whether to bind mount the original repo
 - `--worktree=bind`: Automatically bind mounts the original repo
-- `--worktree=ok`: Skip bind mounting and continue normally
+- `--worktree=skip`: Skip bind mounting and continue normally
 - `--worktree=error`: Exit with error if running in a worktree
 
 ```bash
@@ -45,8 +45,8 @@ yolo
 # Always bind mount in worktrees
 yolo --worktree=bind
 
-# Never bind mount, run without error
-yolo --worktree=ok
+# Skip bind mounting, continue normally
+yolo --worktree=skip
 
 # Disallow running in worktrees
 yolo --worktree=error

--- a/bin/yolo
+++ b/bin/yolo
@@ -25,9 +25,9 @@ while [ $# -gt 0 ]; do
         --worktree=*)
             WORKTREE_MODE="${1#--worktree=}"
             # Validate worktree mode
-            if [[ ! "$WORKTREE_MODE" =~ ^(ask|bind|ok|error)$ ]]; then
+            if [[ ! "$WORKTREE_MODE" =~ ^(ask|bind|skip|error)$ ]]; then
                 echo "Error: Invalid --worktree value: $WORKTREE_MODE" >&2
-                echo "Valid values are: ask, bind, ok, error" >&2
+                echo "Valid values are: ask, bind, skip, error" >&2
                 exit 1
             fi
             shift
@@ -114,7 +114,7 @@ if [ "$is_worktree" -eq 1 ]; then
         bind)
             WORKTREE_MOUNTS+=("-v" "$original_repo_dir:$original_repo_dir:Z")
             ;;
-        ok)
+        skip)
             # Do nothing - skip bind mount
             ;;
         ask)


### PR DESCRIPTION
When the workspace is a git worktree (detected via .git being a symlink or a file with gitdir: reference), add a bind mount for the original repository. This allows Claude to access the original repo's git objects and references, and perform git operations (commit, fetch, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

note: bind mount 'rw' so we could commit etc

---

## Updates (added by Claude Code)

### Addressed review feedback

Per @asmacdo's feedback about security concerns with silent bind mounting, added `--worktree` option with four modes:
- `ask` (default): Prompts user with security warning before bind mounting
- `bind`: Automatically bind mounts original repo  
- `ok`: Skip bind mounting and continue normally
- `error`: Exit if worktree detected

### Contributors

- **Initial implementation**: Claude Code (Claude Opus 4.5) - worktree detection and bind mount logic
- **`--worktree` option modes**: GitHub Copilot (PR #22 merged into this branch)
- **Conflict resolution & rebase onto main**: Claude Code + @asmacdo
- **Review & direction**: @asmacdo, @yarikoptic

### Usage

```bash
# Prompt before mounting (default)
yolo

# Always bind mount
yolo --worktree=bind

# Never bind mount  
yolo --worktree=ok

# Disallow worktrees
yolo --worktree=error
```

**Security note**: Bind mounting the original repo exposes more files and allows modifications. The `ask` prompt helps prevent unintended access.