### PR TITLE
Say to podman to not log outputs in the container

### DIFF
--- a/bin/yolo
+++ b/bin/yolo
@@ -153,7 +153,7 @@ else
     CONTAINER_CMD=("$ENTRYPOINT" "${CLAUDE_ARGS[@]}")
 fi
 
-podman run -it --rm \
+podman run --log-driver=none -it --rm \
     --user="$(id -u):$(id -g)"\
     --userns=keep-id \
     --name="$name" \


### PR DESCRIPTION
I upgraded laptop, has podman 5.7.0 now. And I immediately saw journalctl output flooded with interactions in claude CLI from yolo session. We really do not need that. There is also mode "passthrough-tty" which might work here but I still did not catch why we might need it here if at all. With "none" seems to do the right thing already.  May be with passthrough-tty we could disconnect/reconnect?