### PR TITLE
Strip leading underscores from container name

### DIFF
--- a/bin/yolo
+++ b/bin/yolo
@@ -61,7 +61,8 @@ fi
 
 # Give a meaningful name based on PWD and the PID to help identifying
 # all those podman containers
-name=$( echo "$PWD-$$" | sed -e "s,^$HOME/,,g" -e "s,[^a-zA-Z0-9_.-],_,g" )
+# Note: leading underscores are stripped as they're not allowed in container names
+name=$( echo "$PWD-$$" | sed -e "s,^$HOME/,,g" -e "s,[^a-zA-Z0-9_.-],_,g" -e "s,^_*,," )
 
 CLAUDE_HOME_DIR="$HOME/.claude"
 # must exist but might not if first start on that box


### PR DESCRIPTION
Leading underscores are not allowed in container names. This fixes cases where the path starts with characters that get converted to underscores (like paths starting with '.' or other special characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)