### PR TITLE
Install playwright and chromium (?) inside the container to make claude be able to use playwright inside

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   shellcheck \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Playwright dependencies for Chromium
+RUN npx playwright install-deps chromium
+
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
   chown -R node:node /usr/local/share
@@ -79,6 +82,10 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 
 # Install Claude
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Install Playwright and Chromium browser
+RUN npm install -g playwright && \
+  npx playwright install chromium
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \


### PR DESCRIPTION
Tested while working on https://github.com/yarikoptic/strava-backup and it was able to do tox -e screenshots which it could not do before so I would assume success

- Closes #27 