### PR TITLE
Add tini as init process to reap zombie processes

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -14,6 +14,8 @@ ARG EXTRA_CUDA=""
 ARG EXTRA_PLAYWRIGHT=""
 
 # Install basic development tools
+# tini is included as a minimal init process to properly reap zombie processes
+# when Claude spawns external tools (git, npm, etc.) that may fork children
 RUN apt-get update && apt-get install -y --no-install-recommends \
   dnsutils \
   fzf \
@@ -32,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   procps \
   shellcheck \
   sudo \
+  tini \
   tree \
   unzip \
   vim \
@@ -134,4 +137,6 @@ ENV PATH="/home/node/.local/bin:$PATH"
 RUN uv tool install git-annex && \
   uv cache clean
 
+# Use tini as init process to properly reap zombie processes
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["claude"]


### PR DESCRIPTION
When Claude runs as PID 1 and spawns external tools (git, npm, bash commands, etc.), any orphaned child processes won't be properly reaped since Claude isn't designed to be an init process. This can lead to zombie process accumulation during long-running sessions.

Adding tini as the entrypoint solves this by:
- Running as PID 1 and properly reaping zombie processes
- Forwarding signals (SIGTERM, SIGINT) to Claude for clean shutdown
- Minimal overhead (~20KB, does exactly one job well)

<details>
<summary>exploration under yolo before/after</summary> 

```shell
❯ I will be exploring correct handling of zombies in this environment. Could you please in a loop start a number of short lived processes and see if they survive as zombies 

● I'll create a test that spawns short-lived processes without reaping them, then check for zombies.

● Bash(cat << 'EOF' > /tmp/zombie_test.sh
      #!/bin/bash…)
  ⎿  (No output)

● Bash(/tmp/zombie_test.sh)
  ⎿  Parent PID: 177
     Spawning 10 short-lived child processes...
     Spawned child 1 (PID: 178)
     … +20 lines (ctrl+o to expand)

● The shell subshells were reaped by bash itself. Let me try a more aggressive test using Python where we explicitly don't wait on children:

● Bash(python3 << 'EOF'
      import os…)
  ⎿      PID    PPID STAT COMMAND
         201     200 Z    python3
         202     200 Z    python3
     … +53 lines (ctrl+o to expand)

● We have 10 zombies while the parent is alive (expected). Now let's see if they get reaped when the parent exits and they're reparented to init:

● Bash(echo "Before parent exit - checking for zombies:"
      ps aux | grep ' Z' | grep -v grep || echo "No zombies"…)
  ⎿  Before parent exit - checking for zombies:
     yoh          201  0.1  0.0      0     0 ?        Z    12:37   0:00 [python3] <defunct>
     yoh          202  0.0  0.0      0     0 ?        Z    12:37   0:00 [python3] <defunct>
     … +26 lines (ctrl+o to expand)

● The zombies persist. PID 1 is claude, not tini. Let me check who their parent is now:

● Bash(echo "Current parent of zombies:"
      ps -o pid,ppid,stat,comm -p 201,202,203,204,205 2>/dev/null || echo "PIDs may have changed"…)
  ⎿  Current parent of zombies: ps -o pid,ppid,stat,comm -p 201,202,203,204,205

● Bash(echo "All zombie processes with their parent:"
      ps -eo pid,ppid,stat,comm | grep ' Z '…)
  ⎿      PID    PPID STAT COMMAND
           1       0 Ssl+ claude
         201       1 Z    python3
     … +11 lines (ctrl+o to expand)

● This confirms the problem:

  1. Zombies reparented to PID 1 - all 10 zombies now have PPID=1
  2. PID 1 is claude, not tini
  3. claude is NOT reaping them - the zombies persist

  Let me spawn more to show ongoing accumulation:

● Bash(echo "Current zombie count: $(ps aux | grep -c ' Z ')"…)
  ⎿  Current zombie count: 13

     Spawning 5 more orphan processes...
     … +24 lines (ctrl+o to expand)

● Summary: Zombies accumulate and are NOT being reaped.

  - Started with 10 zombies → now have 18 (and counting)
  - All orphaned processes get reparented to PID 1 (claude)
  - claude as PID 1 does not call wait() to reap them
  - This confirms the need for a proper init like tini

  In a properly configured container with tini as PID 1, these would be reaped immediately upon reparenting. Currently, the claude process runs as PID 1 and doesn't handle the init responsibility of reaping orphan zombies.

❯ now -- I restarted environment, try to do the same and inspect 

● Bash(echo "PID 1 is:"
      ps -p 1 -o pid,comm…)
  ⎿  PID 1 is:
         PID COMMAND
           1 tini
     … +23 lines (ctrl+o to expand)

● Now PID 1 is tini, and all 10 orphan processes were reaped immediately -- zero zombies. Let me spawn more in a loop to stress it a bit:

● Bash(echo "Stress test: spawning 50 orphan processes in rapid succession..."
      python3 -c "…)
  ⎿  Stress test: spawning 50 orphan processes in rapid succession...
     Zombie count after 50 spawns: 0
     … +9 lines (ctrl+o to expand)

● Tini is working correctly. Here's the comparison:
  ┌──────────────────┬────────────────────────┬───────────────────┐
  │                  │    Before (no tini)    │ After (with tini) │
  ├──────────────────┼────────────────────────┼───────────────────┤
  │ PID 1            │ claude                 │ tini              │
  ├──────────────────┼────────────────────────┼───────────────────┤
  │ 10 orphan spawns │ 10 zombies accumulated │ 0 zombies         │
  ├──────────────────┼────────────────────────┼───────────────────┤
  │ 50 rapid spawns  │ would accumulate       │ 0 zombies         │
  ├──────────────────┼────────────────────────┼───────────────────┤
  │ 100 total spawns │ would accumulate       │ 0 zombies         │
  └──────────────────┴────────────────────────┴───────────────────┘
  With tini as PID 1, it properly catches SIGCHLD and calls waitpid() to reap any orphaned child processes the moment they are reparented to it. The claude process now runs as PID 2 under tini, so it no longer needs to handle init responsibilities itself.

```
</details>