### PR TITLE
add datalad and jj extras

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -137,6 +137,30 @@ ENV PATH="/home/node/.local/bin:$PATH"
 RUN uv tool install git-annex && \
   uv cache clean
 
+# Optional extras: datalad and jj
+ARG EXTRA_DATALAD=""
+ARG EXTRA_JJ=""
+ARG JJ_VERSION=0.38.0
+
+# Install DataLad with useful extensions
+RUN if [ "$EXTRA_DATALAD" = "1" ]; then \
+      uv tool install --with datalad-container --with datalad-next datalad && \
+      uv cache clean; \
+    fi
+
+# Install Jujutsu (jj) from GitHub release (musl binary for portability)
+RUN if [ "$EXTRA_JJ" = "1" ]; then \
+      ARCH=$(uname -m) && \
+      wget -qO /tmp/jj.tar.gz \
+        "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-${ARCH}-unknown-linux-musl.tar.gz" && \
+      mkdir -p ~/.local/bin && \
+      tar -xzf /tmp/jj.tar.gz -C ~/.local/bin ./jj && \
+      rm /tmp/jj.tar.gz && \
+      mkdir -p ~/.zfunc && \
+      ~/.local/bin/jj util completion zsh > ~/.zfunc/_jj && \
+      echo 'fpath=(~/.zfunc $fpath)' >> ~/.zshrc; \
+    fi
+
 # Use tini as init process to properly reap zombie processes
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["claude"]

--- a/setup-yolo.sh
+++ b/setup-yolo.sh
@@ -33,6 +33,8 @@ OPTIONS:
                             cuda       - NVIDIA CUDA toolkit for building GPU extensions
                                          (experimental)
                             playwright - Playwright with Chromium for browser automation
+                            datalad    - DataLad with datalad-container and datalad-next
+                            jj         - Jujutsu version control system
                             all        - Enable all extras
 
 EXAMPLES:
@@ -99,12 +101,12 @@ while [[ $# -gt 0 ]]; do
             EXTRAS="${1#*=}"
             # Expand "all" to all available extras
             if [[ "$EXTRAS" == "all" ]]; then
-                EXTRAS="cuda,playwright"
+                EXTRAS="cuda,playwright,datalad,jj"
             fi
             # Validate extras
             for extra in ${EXTRAS//,/ }; do
-                if [[ ! "$extra" =~ ^(cuda|playwright)$ ]]; then
-                    echo "Error: Unknown extra '$extra'. Valid extras: cuda, playwright, all"
+                if [[ ! "$extra" =~ ^(cuda|playwright|datalad|jj)$ ]]; then
+                    echo "Error: Unknown extra '$extra'. Valid extras: cuda, playwright, datalad, jj, all"
                     exit 1
                 fi
             done


### PR DESCRIPTION
Originally suggested to

  - Add `--image=NAME` flag to select derived container images                                                                                            
  - Add two example derived Dockerfiles: `datalad` and `datalad-jj`
  - Auto-detect and offer to build from `images/Dockerfile.<suffix>` on first use

Now chose to

- Add --extras=datalad,jj support to Dockerfile and setup-yolo.sh 

instead, and following the existing extras pattern (cuda, playwright). This avoids duplication and combinatorial
explosion of derived images.