### PR TITLE
Fix HOME defaulting to CWD inside container (#36)

### DIFF
--- a/bin/yolo
+++ b/bin/yolo
@@ -457,6 +457,7 @@ podman run --log-driver=none -it --rm \
     -v "$WORKSPACE_MOUNT" \
     "${WORKTREE_MOUNTS[@]}" \
     -w "$WORKSPACE_DIR" \
+    -e HOME=/home/node \
     -e CLAUDE_CONFIG_DIR="$CLAUDE_DIR" \
     -e GIT_CONFIG_GLOBAL=/tmp/.gitconfig \
     -e CLAUDE_CODE_OAUTH_TOKEN \


### PR DESCRIPTION
- Fixes #36
- potentially relates/effects #46 (attn @just-meng )

I tested on a few sessions - seems to work nice !  Might have "unsandboxing" effect though since now ~/.claude is user's claude so changes do persist

With --userns=keep-id, the host UID has no /etc/passwd entry in the container, so podman defaults HOME to the working directory. This causes several problems:

- ~/.claude resolves to $CWD/.claude instead of the mounted config dir
- Node.js os.homedir() === process.cwd(), so Claude Code treats every workspace as "running from home directory"
- Workspace trust acceptance is only session-scoped (never persisted), causing the "trust this folder?" dialog on every launch

Explicitly set HOME=/home/node (the Dockerfile's user home with shell configs) so that HOME is stable regardless of workspace. Claude Code's config is found via CLAUDE_CONFIG_DIR which is already set independently.