### PR TITLE
Fix UID mapping: use keep-id:uid=1000,gid=1000 

### DIFF
--- a/bin/yolo
+++ b/bin/yolo
@@ -449,8 +449,7 @@ if [ "$USE_NVIDIA" -eq 1 ]; then
 fi
 
 podman run --log-driver=none -it --rm \
-    --user="$(id -u):$(id -g)"\
-    --userns=keep-id \
+    --userns=keep-id:uid=1000,gid=1000 \
     --name="$name" \
     -v "$CLAUDE_MOUNT" \
     -v "$HOME/.gitconfig:/tmp/.gitconfig:ro,z" \


### PR DESCRIPTION
## Summary

Change `--userns=keep-id` to `--userns=keep-id:uid=1000,gid=1000` and drop the
`--user="$(id -u):$(id -g)"` line.

This is a two-line fix that I believe will resolve the root cause behind a handful of issues.

With `keep-id:uid=1000,gid=1000`:
- Host user appears as UID 1000 inside -> matches the existing `node` passwd entry
- HOME=/home/node is set correctly from `/etc/passwd` (no `-e HOME=` hack needed)
- `/home/node` is writable (you own it as UID 1000 inside)
- Files on bind-mounted volumes are still owned by your real host UID outside, and 1000 inside
- `--user` is no longer needed since the namespace mapping already sets the process UID

Requires podman >= 4.3 (October 2022).

## Fixes / relates

- Fixes #36
- Related #46
- Fixes #60 
- Related #8
- Supersedes #55

## Testing

@yarikoptic, since I'm 1000 to verify `keep-id:uid=` works when host UID != container UID, I temporarily
changed the container's `node` user to UID 1001 and used `keep-id:uid=1001,gid=1001`.

Could you give this a try (as is, you shouldnt need below hack) to be sure it will work for you?

<details><summary>Ugly hack to test in my env (not committed): change node UID to 1001 to exercise the mapping</summary>

### Dockerfile change

```diff
+# Change node user from default UID 1000 to 1001 so that keep-id:uid=1001
+# is actually testable by developers whose host UID happens to be 1000
+RUN usermod -u 1001 node && groupmod -g 1001 node && \
+  find / -xdev -user 1000 -exec chown -h 1001 {} + 2>/dev/null; \
+  find / -xdev -group 1000 -exec chgrp -h 1001 {} + 2>/dev/null; \
+  true
```
</details>

<details><summary>Test output (host UID 1000, container node UID 1001)</summary>

```
node@c5dbb8c2a5d8:/home/austin/devel/yolo-legacy$ whoami
node

node@146201fa7466:/home/austin/devel/yolo-legacy$ echo $HOME
/home/node

node@c5dbb8c2a5d8:/home/austin/devel/yolo-legacy$ id -u
1001

node@c5dbb8c2a5d8:/home/austin/devel/yolo-legacy$ ls -lan
total 36
drwxr-xr-x. 1 1001 1001   144 Mar 31 09:26 .
drwxr-xr-t. 1    0    0    30 Mar 31 09:55 ..
-rw-r--r--. 1 1001 1001    59 Mar 31 09:26 .git
drwxr-xr-x. 1 1001 1001    18 Mar 31 09:26 .github
-rw-r--r--. 1 1001 1001   271 Mar 31 09:26 .gitmodules
-rw-r--r--. 1 1001 1001  9877 Mar 31 09:26 README.md
drwxr-xr-x. 1 1001 1001     8 Mar 31 09:45 bin
-rw-r--r--. 1 1001 1001  3077 Mar 31 09:26 config.example
drwxr-xr-x. 1 1001 1001    20 Mar 31 09:44 images
-rwxr-xr-x. 1 1001 1001 10867 Mar 31 09:26 setup-yolo.sh
drwxr-xr-x. 1 1001 1001    40 Mar 31 09:26 tests
```

Host UID 1000 was successfully mapped to container UID 1001 (`node`).
`whoami` resolves, HOME is correct, and workspace files appear owned by the
container's `node` user (1001) which maps back to host UID 1000.

</details>

@just-meng since you just took a dive into this stuff, also curious to hear your thoughts.