### PR TITLE
Add pr-scout spec-audit check

### DIFF
--- a/.github/workflows/pr-scout.yml
+++ b/.github/workflows/pr-scout.yml
@@ -1,0 +1,20 @@
+name: pr-scout
+
+on: pull_request
+permissions:
+  pull-requests: write
+jobs:
+  spec-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: asmacdo/pr-scout@main
+        with:
+          check: spec-audit
+        env:
+          PR_SCOUT_OPENAI_BASE_URL: ${{ secrets.PR_SCOUT_OPENAI_BASE_URL }}
+          PR_SCOUT_OPENAI_API_KEY: ${{ secrets.PR_SCOUT_OPENAI_API_KEY }}
+          PR_SCOUT_MODEL: ${{ secrets.PR_SCOUT_MODEL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a pr-scout workflow that runs the spec-audit check on pull requests
- Posts a PR comment with the audit result (pass/fail/missing spec update)

Requires `PR_SCOUT_OPENAI_BASE_URL`, `PR_SCOUT_OPENAI_API_KEY`, and `PR_SCOUT_MODEL` secrets to be configured.

See [asmacdo/pr-scout](https://github.com/asmacdo/pr-scout) for details.

## Test plan
- [ ] Set secrets in repo settings
- [ ] Verify spec-audit runs and posts a comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)