### PR TITLE
Add apptainer extra

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -294,8 +294,10 @@ nano, ncdu, parallel, procps, shellcheck, sudo, tini, tree, unzip, vim, zsh
 | `EXTRA_JJ`             | `""`     | Set to `"1"` to enable Jujutsu             |
 | `EXTRA_DENO`           | `""`     | Set to `"1"` to enable Deno                |
 | `EXTRA_ENTIRE`         | `""`     | Set to `"1"` to enable Entire CLI          |
+| `EXTRA_APPTAINER`      | `""`     | Set to `"1"` to enable Apptainer           |
 | `JJ_VERSION`           | `0.38.0` | Jujutsu version                            |
 | `DENO_VERSION`         | `""`     | Deno version (empty = latest)              |
+| `APPTAINER_VERSION`    | `1.4.5`  | Apptainer version                          |
 | `GIT_DELTA_VERSION`    | `0.18.2` | git-delta version                          |
 | `ZSH_IN_DOCKER_VERSION` | `1.2.0`  | zsh-in-docker version                      |
 
@@ -309,6 +311,7 @@ nano, ncdu, parallel, procps, shellcheck, sudo, tini, tree, unzip, vim, zsh
 | `jj`         | Musl binary from GitHub release + zsh completion                        |
 | `deno`       | Deno JS/TS runtime via install script + zsh/bash PATH setup             |
 | `entire`     | Entire CLI via temporary Go toolchain install (`entireio/cli` v0.5.3)   |
+| `apptainer`  | Apptainer `.deb` from upstream GitHub release (amd64 only; bookworm/trixie auto-detected) |
 
 ### Container Environment
 
@@ -339,7 +342,7 @@ setup-yolo.sh [OPTIONS]
 | `--build=MODE`     | `auto`  | `auto`, `yes`, `no`                          | Image build control    |
 | `--install=MODE`   | `auto`  | `auto`, `yes`, `no`                          | Script install control |
 | `--packages=PKGS`  | `""`    | comma/space-separated                        | Extra apt packages     |
-| `--extras=EXTRAS`  | `""`    | `cuda`, `playwright`, `datalad`, `jj`, `deno`, `entire`, `all` | Predefined extras      |
+| `--extras=EXTRAS`  | `""`    | `cuda`, `playwright`, `datalad`, `jj`, `deno`, `entire`, `apptainer`, `all` | Predefined extras      |
 
 ### Build Behavior
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -62,6 +62,29 @@ RUN if [ "$EXTRA_CUDA" = "1" ]; then \
       && apt-get clean && rm -rf /var/lib/apt/lists/*; \
     fi
 
+# Apptainer (rootless container/SIF runtime) — upstream Debian install instructions:
+# https://apptainer.org/docs/admin/main/installation.html#install-debian-packages
+ARG EXTRA_APPTAINER=""
+ARG APPTAINER_VERSION=1.4.5
+RUN if [ "$EXTRA_APPTAINER" = "1" ]; then \
+      ARCH=$(dpkg --print-architecture) && \
+      if [ "$ARCH" != "amd64" ]; then \
+        echo "EXTRA_APPTAINER only supports amd64 (got $ARCH); upstream publishes amd64 .deb only" && exit 1; \
+      fi && \
+      . /etc/os-release && \
+      if [ "$VERSION_CODENAME" = "trixie" ] || [ "$VERSION_CODENAME" = "forky" ] || [ "$VERSION_CODENAME" = "sid" ]; then \
+        DEB="apptainer_${APPTAINER_VERSION}-trixie+_amd64.deb"; \
+      else \
+        DEB="apptainer_${APPTAINER_VERSION}_amd64.deb"; \
+      fi && \
+      wget -qO "/tmp/${DEB}" \
+        "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/${DEB}" && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends "/tmp/${DEB}" && \
+      apt-get clean && rm -rf /var/lib/apt/lists/* && \
+      rm "/tmp/${DEB}"; \
+    fi
+
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
   chown -R node:node /usr/local/share

--- a/setup-yolo.sh
+++ b/setup-yolo.sh
@@ -37,6 +37,7 @@ OPTIONS:
                             jj         - Jujutsu version control system
                             deno       - Deno JS/TS runtime and formatter
                             entire     - Entire CLI (entireio/cli)
+                            apptainer  - Apptainer container runtime (rootless)
                             all        - Enable all extras
 
 EXAMPLES:
@@ -103,12 +104,12 @@ while [[ $# -gt 0 ]]; do
             EXTRAS="${1#*=}"
             # Expand "all" to all available extras
             if [[ "$EXTRAS" == "all" ]]; then
-                EXTRAS="cuda,playwright,datalad,jj,deno,entire"
+                EXTRAS="cuda,playwright,datalad,jj,deno,entire,apptainer"
             fi
             # Validate extras
             for extra in ${EXTRAS//,/ }; do
-                if [[ ! "$extra" =~ ^(cuda|playwright|datalad|jj|deno|entire)$ ]]; then
-                    echo "Error: Unknown extra '$extra'. Valid extras: cuda, playwright, datalad, jj, deno, entire, all"
+                if [[ ! "$extra" =~ ^(cuda|playwright|datalad|jj|deno|entire|apptainer)$ ]]; then
+                    echo "Error: Unknown extra '$extra'. Valid extras: cuda, playwright, datalad, jj, deno, entire, apptainer, all"
                     exit 1
                 fi
             done


### PR DESCRIPTION
Installs Apptainer following upstream Debian instructions: download the .deb from the apptainer/apptainer GitHub release and install via apt so runtime deps are pulled in. Picks the trixie+ vs default .deb based on /etc/os-release VERSION_CODENAME and fails on non-amd64 (upstream publishes amd64 .deb only).

Wires the new extra through setup-yolo.sh (help, --extras=all expansion, validation regex) and SPEC.md (build args, optional extras, setup script flags).