### PR TITLE
Bust layer cache to ensure Claude Code upgrades on rebuild

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -220,6 +220,8 @@ RUN if [ "$EXTRA_ENTIRE" = "1" ]; then \
     fi
 
 # Install Claude
+# Cache-bust: pass --build-arg CLAUDE_CACHEBUST=$(date +%s) to force a fresh install
+ARG CLAUDE_CACHEBUST=
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # Use tini as init process to properly reap zombie processes

--- a/setup-yolo.sh
+++ b/setup-yolo.sh
@@ -155,7 +155,7 @@ elif [ "$BUILD_MODE" = "yes" ] || [ "$IMAGE_EXISTS" = false ]; then
     echo
 
     TZ=$(timedatectl show --property=Timezone --value 2>/dev/null || echo "UTC")
-    BUILD_ARGS=(--build-arg "TZ=$TZ")
+    BUILD_ARGS=(--build-arg "TZ=$TZ" --build-arg "CLAUDE_CACHEBUST=$(date +%s)")
     if [ -n "$EXTRA_PACKAGES" ]; then
         BUILD_ARGS+=(--build-arg "EXTRA_PACKAGES=$EXTRA_PACKAGES")
     fi


### PR DESCRIPTION
## Summary

- Add `CLAUDE_CACHEBUST` build arg before the `npm install` layer in the Dockerfile so Podman doesn't reuse a stale cached layer
- Pass `--build-arg CLAUDE_CACHEBUST=$(date +%s)` automatically in `setup-yolo.sh` when building

Fixes #74

## Test plan

- [ ] Run `./setup-yolo.sh --build=yes` and verify the build log shows `npm install` actually running (not cached)
- [ ] Confirm `claude --version` inside the container matches the latest npm version