### PR TITLE
Add --tag option to build/run image tags other than latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,24 @@ jobs:
           # Verify the image was built
           podman image exists con-bomination-claude-code
 
+      - name: Test --tag handling (no rebuild)
+        run: |
+          # A tag that was never built must fail with --build=no
+          if ./setup-yolo.sh --tag=never-built --build=no --install=no; then
+            echo "Expected failure for missing tagged image"
+            exit 1
+          fi
+
+          # Tag the image built above and verify setup finds it by tag
+          podman tag con-bomination-claude-code:latest con-bomination-claude-code:citest
+          ./setup-yolo.sh --tag=citest --build=no --install=no
+
+          # An invalid tag must be rejected
+          if ./setup-yolo.sh --tag="bad:tag" --build=no --install=no; then
+            echo "Expected failure for invalid tag"
+            exit 1
+          fi
+
       - name: Verify yolo script syntax
         run: |
           bash -n bin/yolo
@@ -96,6 +114,10 @@ jobs:
 
           echo "Testing: yolo -v /data:/data --"
           ./bin/yolo -v /data:/data -- || true
+
+          echo "Testing: yolo --tag=citest"
+          ./bin/yolo --tag=citest | grep -q "con-bomination-claude-code:citest"
+          echo "✓ --tag is passed through to podman run"
 
   integration-test:
     name: Integration Test

--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ YOLO_IMAGE_TAG="test"
 - `"~/data::ro"` → `~/data:~/data:ro,Z` (1-to-1 with options)
 - `"~/data:/data:Z"` → `~/data:/data:Z` (explicit, unchanged)
 
-Command line options always override configuration file settings. Use `--no-config` to ignore the configuration file entirely.
+Use `--no-config` to ignore the configuration files entirely.
+
+Note on precedence: config files are sourced after the command line is parsed,
+so `USE_ANONYMIZED_PATHS`, `USE_NVIDIA`, and `WORKTREE_MODE` set in a config
+file override the matching command line flag. `YOLO_IMAGE_TAG` is the
+exception — `--tag` always wins over the config files and the environment.
 
 See `config.example` for a complete configuration template with detailed comments.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ If you prefer the old behavior with anonymized paths (`/claude` and `/workspace`
 yolo --anonymized-paths
 ```
 
+### Image Tags
+
+The container image is `con-bomination-claude-code` and is tagged `latest` by
+default. Both scripts accept a `--tag` option so you can build and run
+alternative images (e.g. to test a Dockerfile change) without clobbering the
+image you use every day:
+
+```bash
+# Build a test image as con-bomination-claude-code:test,
+# leaving :latest and ~/.local/bin/yolo untouched
+./setup-yolo.sh --build=yes --install=no --tag=test
+
+# Run it
+yolo --tag=test
+
+# Back to the default image
+yolo
+```
+
+The tag can also be set per project or user-wide via `YOLO_IMAGE_TAG` in the
+config file (or in the environment); `--tag` overrides both.
+
 ### Git Worktree Support
 
 When running in a git worktree, `yolo` can detect and optionally bind mount the original repository. This allows Claude to access git objects and perform operations like commit and fetch. Control this behavior with the `--worktree` option:
@@ -94,6 +116,9 @@ YOLO_CLAUDE_ARGS=(
 
 # Default flags
 USE_NVIDIA=1
+
+# Image tag to run (default: latest)
+YOLO_IMAGE_TAG="test"
 ```
 
 **Volume shorthand syntax:**
@@ -123,8 +148,11 @@ Your credentials are stored in `~/.claude` on your host, so you only need to log
 If you prefer to run commands manually, first build the image from the `images/` directory:
 
 ```bash
-podman build --build-arg TZ=$(timedatectl show --property=Timezone --value) -t con-bomination-claude-code images/
+podman build --build-arg TZ=$(timedatectl show --property=Timezone --value) -t con-bomination-claude-code:latest images/
 ```
+
+(Use another tag, e.g. `-t con-bomination-claude-code:test`, to keep test images
+around; `yolo --tag=test` then runs it.)
 
 Then run (with original host paths preserved by default):
 
@@ -137,7 +165,7 @@ podman run -it --rm \
   -w "$(pwd)" \
   -e CLAUDE_CONFIG_DIR="$HOME/.claude" \
   -e GIT_CONFIG_GLOBAL=/tmp/.gitconfig \
-  con-bomination-claude-code \
+  con-bomination-claude-code:latest \
   claude --dangerously-skip-permissions
 ```
 
@@ -152,7 +180,7 @@ podman run -it --rm \
   -w /workspace \
   -e CLAUDE_CONFIG_DIR=/claude \
   -e GIT_CONFIG_GLOBAL=/tmp/.gitconfig \
-  con-bomination-claude-code \
+  con-bomination-claude-code:latest \
   claude --dangerously-skip-permissions
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -80,22 +80,29 @@ auto-created from the built-in template and a message is printed to stderr.
 
 User-wide and project arrays are concatenated (user-wide first).
 
-#### Scalars (project overrides user-wide; CLI overrides both)
+#### Scalars (project overrides user-wide)
 
-| Key                    | Type     | Default  | Description                    |
-|------------------------|----------|----------|--------------------------------|
-| `USE_ANONYMIZED_PATHS` | `0\|1`   | `0`      | Use anonymized container paths |
-| `USE_NVIDIA`           | `0\|1`   | `0`      | Enable NVIDIA GPU passthrough  |
-| `WORKTREE_MODE`        | `string` | `ask`    | Git worktree handling mode     |
-| `YOLO_IMAGE_TAG`       | `string` | `latest` | Image tag to run               |
+| Key                    | Type     | Default  | Description                    | Precedence                     |
+|------------------------|----------|----------|--------------------------------|--------------------------------|
+| `USE_ANONYMIZED_PATHS` | `0\|1`   | `0`      | Use anonymized container paths | config overrides CLI           |
+| `USE_NVIDIA`           | `0\|1`   | `0`      | Enable NVIDIA GPU passthrough  | config overrides CLI           |
+| `WORKTREE_MODE`        | `string` | `ask`    | Git worktree handling mode     | config overrides CLI           |
+| `YOLO_IMAGE_TAG`       | `string` | `latest` | Image tag to run               | CLI (`--tag`) overrides config |
 
-`YOLO_IMAGE_TAG` may also be set in the environment; config files override the
-environment and `--tag` overrides both. Tags must match
-`^[A-Za-z0-9_][A-Za-z0-9._-]*$`; an invalid tag is a hard error.
+Config files are sourced *after* the command line is parsed, so for
+`USE_ANONYMIZED_PATHS`, `USE_NVIDIA`, and `WORKTREE_MODE` a value set in a
+config file silently overrides the corresponding flag (e.g. `USE_NVIDIA=0` in
+`.git/yolo/config` defeats `yolo --nvidia`). This is a known wart, not a
+design goal.
+
+`YOLO_IMAGE_TAG` is resolved explicitly after config loading instead: it may
+also be set in the environment, config files override the environment, and
+`--tag` overrides both. Tags must match `^[A-Za-z0-9_][A-Za-z0-9._-]*$`; an
+invalid tag is a hard error.
 
 ### Loading Order
 
-1. Parse CLI flags (sets defaults and overrides).
+1. Parse CLI flags (sets initial scalar values; steps 2 and 5 can overwrite them).
 2. Source user-wide config (if exists and `--no-config` not set).
 3. Locate `.git` directory (traverses up from `$PWD`; handles worktrees).
 4. Auto-create `.git/yolo/config` if `.git/yolo/` directory doesn't exist.

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,12 +8,12 @@ per-action approval to keep the host safe.
 
 ## Components
 
-| Component          | Path             | Purpose                                          |
-|--------------------|------------------|--------------------------------------------------|
-| `bin/yolo`         | CLI wrapper      | Parses args, loads config, invokes `podman run`   |
-| `setup-yolo.sh`    | Setup script     | Builds the container image and installs `bin/yolo` |
-| `images/Dockerfile` | Image definition | Development environment with Claude Code          |
-| `config.example`   | Template         | Documented config file template                   |
+| Component           | Path             | Purpose                                            |
+|---------------------|------------------|----------------------------------------------------|
+| `bin/yolo`          | CLI wrapper      | Parses args, loads config, invokes `podman run`    |
+| `setup-yolo.sh`     | Setup script     | Builds the container image and installs `bin/yolo` |
+| `images/Dockerfile` | Image definition | Development environment with Claude Code           |
+| `config.example`    | Template         | Documented config file template                    |
 
 ---
 
@@ -30,18 +30,18 @@ claude. If no `--` is present, all positional arguments go to claude.
 
 ### Flags
 
-| Flag                 | Default  | Description                                                  |
-|----------------------|----------|--------------------------------------------------------------|
-| `-h`, `--help`       | —        | Show help and exit                                           |
-| `--anonymized-paths` | off      | Use `/claude` and `/workspace` instead of host paths         |
-| `--entrypoint=CMD`   | `claude` | Override container entrypoint                                |
-| `--entrypoint CMD`   | `claude` | Same, space-separated form                                   |
-| `--tag=TAG`          | `latest` | Image tag to run (`con-bomination-claude-code:TAG`)          |
-| `--tag TAG`          | `latest` | Same, space-separated form                                   |
-| `--worktree=MODE`    | `ask`    | Git worktree handling: `ask`, `bind`, `skip`, `error`        |
-| `--nvidia`           | off      | Enable NVIDIA GPU passthrough via CDI                        |
-| `--no-config`        | off      | Ignore all configuration files                               |
-| `--install-config`   | —        | Create or display `.git/yolo/config` template, then exit     |
+| Flag                 | Default  | Description                                              |
+|----------------------|----------|----------------------------------------------------------|
+| `-h`, `--help`       | —        | Show help and exit                                       |
+| `--anonymized-paths` | off      | Use `/claude` and `/workspace` instead of host paths     |
+| `--entrypoint=CMD`   | `claude` | Override container entrypoint                            |
+| `--entrypoint CMD`   | `claude` | Same, space-separated form                               |
+| `--tag=TAG`          | `latest` | Image tag to run (`con-bomination-claude-code:TAG`)      |
+| `--tag TAG`          | `latest` | Same, space-separated form                               |
+| `--worktree=MODE`    | `ask`    | Git worktree handling: `ask`, `bind`, `skip`, `error`    |
+| `--nvidia`           | off      | Enable NVIDIA GPU passthrough via CDI                    |
+| `--no-config`        | off      | Ignore all configuration files                           |
+| `--install-config`   | —        | Create or display `.git/yolo/config` template, then exit |
 
 ### Argument Routing
 
@@ -56,8 +56,8 @@ claude. If no `--` is present, all positional arguments go to claude.
 
 ### File Locations
 
-| Scope       | Path                                       | Precedence |
-|-------------|--------------------------------------------|------------|
+| Scope       | Path                                        | Precedence |
+|-------------|---------------------------------------------|------------|
 | User-wide   | `${XDG_CONFIG_HOME:-~/.config}/yolo/config` | Lower      |
 | Per-project | `.git/yolo/config`                          | Higher     |
 
@@ -72,22 +72,22 @@ auto-created from the built-in template and a message is printed to stderr.
 
 #### Arrays (merged: user-wide + project)
 
-| Key                    | Type       | Description                        |
-|------------------------|------------|------------------------------------|
-| `YOLO_PODMAN_VOLUMES`  | `string[]` | Volume mount specifications        |
-| `YOLO_PODMAN_OPTIONS`  | `string[]` | Additional `podman run` options    |
-| `YOLO_CLAUDE_ARGS`     | `string[]` | Arguments passed to claude         |
+| Key                   | Type       | Description                     |
+|-----------------------|------------|---------------------------------|
+| `YOLO_PODMAN_VOLUMES` | `string[]` | Volume mount specifications     |
+| `YOLO_PODMAN_OPTIONS` | `string[]` | Additional `podman run` options |
+| `YOLO_CLAUDE_ARGS`    | `string[]` | Arguments passed to claude      |
 
 User-wide and project arrays are concatenated (user-wide first).
 
 #### Scalars (project overrides user-wide; CLI overrides both)
 
-| Key                    | Type     | Default | Description                    |
-|------------------------|----------|---------|--------------------------------|
-| `USE_ANONYMIZED_PATHS` | `0\|1`   | `0`     | Use anonymized container paths |
-| `USE_NVIDIA`           | `0\|1`   | `0`     | Enable NVIDIA GPU passthrough  |
-| `WORKTREE_MODE`        | `string` | `ask`   | Git worktree handling mode     |
-| `YOLO_IMAGE_TAG`       | `string` | `latest` | Image tag to run              |
+| Key                    | Type     | Default  | Description                    |
+|------------------------|----------|----------|--------------------------------|
+| `USE_ANONYMIZED_PATHS` | `0\|1`   | `0`      | Use anonymized container paths |
+| `USE_NVIDIA`           | `0\|1`   | `0`      | Enable NVIDIA GPU passthrough  |
+| `WORKTREE_MODE`        | `string` | `ask`    | Git worktree handling mode     |
+| `YOLO_IMAGE_TAG`       | `string` | `latest` | Image tag to run               |
 
 `YOLO_IMAGE_TAG` may also be set in the environment; config files override the
 environment and `--tag` overrides both. Tags must match
@@ -112,23 +112,23 @@ environment and `--tag` overrides both. Tags must match
 
 ### Shorthand Expansion (`expand_volume`)
 
-| Input                   | Output                              | Rule                                         |
-|-------------------------|-------------------------------------|----------------------------------------------|
-| `~/projects`            | `$HOME/projects:$HOME/projects:Z`   | 1-to-1 with `:Z`                             |
-| `~/data::ro`            | `$HOME/data:$HOME/data:ro`          | 1-to-1 with custom options (no `:Z` appended) |
-| `/host:/container`      | `/host:/container:Z`                | Partial form, `:Z` appended                  |
-| `/host:/container:opts` | `/host:/container:opts`             | Full form, passed through unchanged          |
+| Input                   | Output                            | Rule                                          |
+|-------------------------|-----------------------------------|-----------------------------------------------|
+| `~/projects`            | `$HOME/projects:$HOME/projects:Z` | 1-to-1 with `:Z`                              |
+| `~/data::ro`            | `$HOME/data:$HOME/data:ro`        | 1-to-1 with custom options (no `:Z` appended) |
+| `/host:/container`      | `/host:/container:Z`              | Partial form, `:Z` appended                   |
+| `/host:/container:opts` | `/host:/container:opts`           | Full form, passed through unchanged           |
 
 Tilde (`~`) is expanded to `$HOME` in shorthand and `::` forms.
 
 ### Default Mounts
 
-| Mount         | Host Path            | Container Path               | Options               |
-|---------------|----------------------|------------------------------|-----------------------|
-| Claude home   | `~/.claude`          | `~/.claude` or `/claude`     | `:z` (rw, shared)     |
-| Git config    | `~/.gitconfig`       | `/tmp/.gitconfig`            | `ro,z` (shared)       |
-| Workspace     | `$(pwd)`             | `$(pwd)` or `/workspace`     | `:z` (rw, shared)     |
-| Worktree repo | `$original_repo_dir` | `$original_repo_dir`         | `:z` (rw, conditional) |
+| Mount         | Host Path            | Container Path           | Options                |
+|---------------|----------------------|--------------------------|------------------------|
+| Claude home   | `~/.claude`          | `~/.claude` or `/claude` | `:z` (rw, shared)      |
+| Git config    | `~/.gitconfig`       | `/tmp/.gitconfig`        | `ro,z` (shared)        |
+| Workspace     | `$(pwd)`             | `$(pwd)` or `/workspace` | `:z` (rw, shared)      |
+| Worktree repo | `$original_repo_dir` | `$original_repo_dir`     | `:z` (rw, conditional) |
 
 Default mounts use lowercase `:z` (shared SELinux label) to allow multiple
 concurrent yolo containers to access the same paths without EACCES errors.
@@ -141,23 +141,23 @@ The `~/.claude` directory is auto-created if missing.
 
 ### Preserved Paths (default)
 
-| Variable          | Value                            |
-|-------------------|----------------------------------|
-| `CLAUDE_DIR`      | `$HOME/.claude`                  |
-| `WORKSPACE_DIR`   | `$(pwd)`                         |
-| `CLAUDE_MOUNT`    | `$HOME/.claude:$HOME/.claude:z`  |
-| `WORKSPACE_MOUNT` | `$(pwd):$(pwd):z`                |
+| Variable          | Value                           |
+|-------------------|---------------------------------|
+| `CLAUDE_DIR`      | `$HOME/.claude`                 |
+| `WORKSPACE_DIR`   | `$(pwd)`                        |
+| `CLAUDE_MOUNT`    | `$HOME/.claude:$HOME/.claude:z` |
+| `WORKSPACE_MOUNT` | `$(pwd):$(pwd):z`               |
 
 Sessions are compatible between container and native Claude Code.
 
 ### Anonymized Paths (`--anonymized-paths`)
 
-| Variable          | Value                       |
-|-------------------|-----------------------------|
-| `CLAUDE_DIR`      | `/claude`                   |
-| `WORKSPACE_DIR`   | `/workspace`                |
-| `CLAUDE_MOUNT`    | `$HOME/.claude:/claude:z`   |
-| `WORKSPACE_MOUNT` | `$(pwd):/workspace:z`       |
+| Variable          | Value                     |
+|-------------------|---------------------------|
+| `CLAUDE_DIR`      | `/claude`                 |
+| `WORKSPACE_DIR`   | `/workspace`              |
+| `CLAUDE_MOUNT`    | `$HOME/.claude:/claude:z` |
+| `WORKSPACE_MOUNT` | `$(pwd):/workspace:z`     |
 
 All projects appear at `/workspace`, enabling cross-project session context.
 
@@ -175,12 +175,12 @@ All projects appear at `/workspace`, enabling cross-project session context.
 
 ### Handling Modes
 
-| Mode    | Behavior                                         |
-|---------|--------------------------------------------------|
-| `ask`   | Prompt user; warn about security implications    |
-| `bind`  | Automatically mount original repo                |
-| `skip`  | Do not mount original repo; continue normally    |
-| `error` | Exit with error if worktree detected             |
+| Mode    | Behavior                                      |
+|---------|-----------------------------------------------|
+| `ask`   | Prompt user; warn about security implications |
+| `bind`  | Automatically mount original repo             |
+| `skip`  | Do not mount original repo; continue normally |
+| `error` | Exit with error if worktree detected          |
 
 When mounted, the original repo is bind-mounted at its host path with `:z`.
 
@@ -224,30 +224,30 @@ When `USE_NVIDIA=1`:
 
 ### Fixed `podman run` Arguments
 
-| Argument       | Value                          | Purpose                            |
-|----------------|--------------------------------|------------------------------------|
-| `--log-driver` | `none`                         | No container logging               |
-| `-it`          | —                              | Interactive + TTY                  |
-| `--rm`         | —                              | Auto-remove on exit                |
-| `--userns`     | `keep-id:uid=1000,gid=1000`    | Map host UID/GID to 1000 (node)   |
-| `--name`       | generated                      | Container name from PWD + PID      |
-| `-w`           | `$WORKSPACE_DIR`               | Working directory                  |
+| Argument       | Value                       | Purpose                         |
+|----------------|-----------------------------|---------------------------------|
+| `--log-driver` | `none`                      | No container logging            |
+| `-it`          | —                           | Interactive + TTY               |
+| `--rm`         | —                           | Auto-remove on exit             |
+| `--userns`     | `keep-id:uid=1000,gid=1000` | Map host UID/GID to 1000 (node) |
+| `--name`       | generated                   | Container name from PWD + PID   |
+| `-w`           | `$WORKSPACE_DIR`            | Working directory               |
 
 ### Environment Variables
 
-| Variable                                 | Value              | Purpose                       |
-|------------------------------------------|--------------------|-------------------------------|
-| `CLAUDE_CONFIG_DIR`                      | `$CLAUDE_DIR`      | Claude config location        |
-| `GIT_CONFIG_GLOBAL`                      | `/tmp/.gitconfig`  | Git identity                  |
-| `CLAUDE_CODE_OAUTH_TOKEN`                | passthrough        | Auth token (if set on host)   |
-| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`   | passthrough        | Agent teams (if set on host)  |
+| Variable                               | Value             | Purpose                      |
+|----------------------------------------|-------------------|------------------------------|
+| `CLAUDE_CONFIG_DIR`                    | `$CLAUDE_DIR`     | Claude config location       |
+| `GIT_CONFIG_GLOBAL`                    | `/tmp/.gitconfig` | Git identity                 |
+| `CLAUDE_CODE_OAUTH_TOKEN`              | passthrough       | Auth token (if set on host)  |
+| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | passthrough       | Agent teams (if set on host) |
 
 ### Container Command
 
-| Entrypoint               | Command                                                    |
-|--------------------------|------------------------------------------------------------|
-| Default (`claude`)       | `claude --dangerously-skip-permissions [CLAUDE_ARGS]`      |
-| Custom (`--entrypoint=X`) | `X [CLAUDE_ARGS]` (no `--dangerously-skip-permissions`)    |
+| Entrypoint                | Command                                                 |
+|---------------------------|---------------------------------------------------------|
+| Default (`claude`)        | `claude --dangerously-skip-permissions [CLAUDE_ARGS]`   |
+| Custom (`--entrypoint=X`) | `X [CLAUDE_ARGS]` (no `--dangerously-skip-permissions`) |
 
 ### Image
 
@@ -285,56 +285,56 @@ nano, ncdu, parallel, procps, shellcheck, sudo, tini, tree, unzip, vim, zsh
 
 ### Always-installed Tools
 
-| Tool                 | Install Method                                                |
-|----------------------|---------------------------------------------------------------|
-| Claude Code          | `npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}` |
-| git-delta            | deb package from GitHub release (v0.18.2)                     |
-| git-annex            | `uv tool install git-annex`                                   |
-| uv                   | curl installer from astral.sh                                 |
-| zsh + powerlevel10k  | zsh-in-docker v1.2.0 with git, fzf plugins                   |
+| Tool                | Install Method                                                    |
+|---------------------|-------------------------------------------------------------------|
+| Claude Code         | `npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}` |
+| git-delta           | deb package from GitHub release (v0.18.2)                         |
+| git-annex           | `uv tool install git-annex`                                       |
+| uv                  | curl installer from astral.sh                                     |
+| zsh + powerlevel10k | zsh-in-docker v1.2.0 with git, fzf plugins                        |
 
 ### Build Arguments
 
-| Arg                    | Default  | Description                                |
-|------------------------|----------|--------------------------------------------|
-| `TZ`                   | from host | Timezone                                   |
-| `CLAUDE_CODE_VERSION`  | `latest` | Claude Code npm version                    |
-| `EXTRA_PACKAGES`       | `""`     | Space-separated apt packages               |
-| `EXTRA_CUDA`           | `""`     | Set to `"1"` to enable CUDA toolkit        |
-| `EXTRA_PLAYWRIGHT`     | `""`     | Set to `"1"` to enable Playwright + Chromium |
-| `EXTRA_DATALAD`        | `""`     | Set to `"1"` to enable DataLad             |
-| `EXTRA_JJ`             | `""`     | Set to `"1"` to enable Jujutsu             |
-| `EXTRA_DENO`           | `""`     | Set to `"1"` to enable Deno                |
-| `EXTRA_ENTIRE`         | `""`     | Set to `"1"` to enable Entire CLI          |
-| `EXTRA_APPTAINER`      | `""`     | Set to `"1"` to enable Apptainer           |
-| `JJ_VERSION`           | `0.38.0` | Jujutsu version                            |
-| `DENO_VERSION`         | `""`     | Deno version (empty = latest)              |
-| `APPTAINER_VERSION`    | `1.4.5`  | Apptainer version                          |
-| `GIT_DELTA_VERSION`    | `0.18.2` | git-delta version                          |
-| `ZSH_IN_DOCKER_VERSION` | `1.2.0`  | zsh-in-docker version                      |
+| Arg                     | Default   | Description                                  |
+|-------------------------|-----------|----------------------------------------------|
+| `TZ`                    | from host | Timezone                                     |
+| `CLAUDE_CODE_VERSION`   | `latest`  | Claude Code npm version                      |
+| `EXTRA_PACKAGES`        | `""`      | Space-separated apt packages                 |
+| `EXTRA_CUDA`            | `""`      | Set to `"1"` to enable CUDA toolkit          |
+| `EXTRA_PLAYWRIGHT`      | `""`      | Set to `"1"` to enable Playwright + Chromium |
+| `EXTRA_DATALAD`         | `""`      | Set to `"1"` to enable DataLad               |
+| `EXTRA_JJ`              | `""`      | Set to `"1"` to enable Jujutsu               |
+| `EXTRA_DENO`            | `""`      | Set to `"1"` to enable Deno                  |
+| `EXTRA_ENTIRE`          | `""`      | Set to `"1"` to enable Entire CLI            |
+| `EXTRA_APPTAINER`       | `""`      | Set to `"1"` to enable Apptainer             |
+| `JJ_VERSION`            | `0.38.0`  | Jujutsu version                              |
+| `DENO_VERSION`          | `""`      | Deno version (empty = latest)                |
+| `APPTAINER_VERSION`     | `1.4.5`   | Apptainer version                            |
+| `GIT_DELTA_VERSION`     | `0.18.2`  | git-delta version                            |
+| `ZSH_IN_DOCKER_VERSION` | `1.2.0`   | zsh-in-docker version                        |
 
 ### Optional Extras
 
-| Extra        | What's Installed                                                        |
-|--------------|-------------------------------------------------------------------------|
-| `cuda`       | `nvidia-cuda-toolkit` (enables non-free/contrib apt sources)            |
-| `playwright` | System deps + `npm install -g playwright` + Chromium browser            |
-| `datalad`    | `uv tool install --with datalad-container --with datalad-next datalad`  |
-| `jj`         | Musl binary from GitHub release + zsh completion                        |
-| `deno`       | Deno JS/TS runtime via install script + zsh/bash PATH setup             |
-| `entire`     | Entire CLI via temporary Go toolchain install (`entireio/cli` v0.6.1)   |
+| Extra        | What's Installed                                                                          |
+|--------------|-------------------------------------------------------------------------------------------|
+| `cuda`       | `nvidia-cuda-toolkit` (enables non-free/contrib apt sources)                              |
+| `playwright` | System deps + `npm install -g playwright` + Chromium browser                              |
+| `datalad`    | `uv tool install --with datalad-container --with datalad-next datalad`                    |
+| `jj`         | Musl binary from GitHub release + zsh completion                                          |
+| `deno`       | Deno JS/TS runtime via install script + zsh/bash PATH setup                               |
+| `entire`     | Entire CLI via temporary Go toolchain install (`entireio/cli` v0.6.1)                     |
 | `apptainer`  | Apptainer `.deb` from upstream GitHub release (amd64 only; bookworm/trixie auto-detected) |
 
 ### Container Environment
 
-| Variable             | Value                          |
-|----------------------|--------------------------------|
-| `DEVCONTAINER`       | `true`                         |
-| `SHELL`              | `/bin/zsh`                     |
-| `EDITOR`             | `vim`                          |
-| `VISUAL`             | `vim`                          |
-| `NPM_CONFIG_PREFIX`  | `/usr/local/share/npm-global`  |
-| `PATH`               | Includes npm-global/bin, `~/.local/bin`, `~/.deno/bin` |
+| Variable            | Value                                                  |
+|---------------------|--------------------------------------------------------|
+| `DEVCONTAINER`      | `true`                                                 |
+| `SHELL`             | `/bin/zsh`                                             |
+| `EDITOR`            | `vim`                                                  |
+| `VISUAL`            | `vim`                                                  |
+| `NPM_CONFIG_PREFIX` | `/usr/local/share/npm-global`                          |
+| `PATH`              | Includes npm-global/bin, `~/.local/bin`, `~/.deno/bin` |
 
 ---
 
@@ -348,14 +348,18 @@ setup-yolo.sh [OPTIONS]
 
 ### Flags
 
-| Flag               | Default | Values                                       | Description            |
-|--------------------|---------|----------------------------------------------|------------------------|
-| `-h`, `--help`     | —       | —                                            | Show help and exit     |
-| `--build=MODE`     | `auto`  | `auto`, `yes`, `no`                          | Image build control    |
-| `--install=MODE`   | `auto`  | `auto`, `yes`, `no`                          | Script install control |
-| `--tag=TAG`        | `latest` | tag matching `^[A-Za-z0-9_][A-Za-z0-9._-]*$` | Tag to build/check     |
-| `--packages=PKGS`  | `""`    | comma/space-separated                        | Extra apt packages     |
-| `--extras=EXTRAS`  | `""`    | `cuda`, `playwright`, `datalad`, `jj`, `deno`, `entire`, `apptainer`, `all` | Predefined extras      |
+| Flag              | Default  | Values                 | Description            |
+|-------------------|----------|------------------------|------------------------|
+| `-h`, `--help`    | —        | —                      | Show help and exit     |
+| `--build=MODE`    | `auto`   | `auto`, `yes`, `no`    | Image build control    |
+| `--install=MODE`  | `auto`   | `auto`, `yes`, `no`    | Script install control |
+| `--tag=TAG`       | `latest` | any valid image tag    | Tag to build/check     |
+| `--packages=PKGS` | `""`     | comma/space-separated  | Extra apt packages     |
+| `--extras=EXTRAS` | `""`     | comma-separated extras | Predefined extras      |
+
+Valid extras: `cuda`, `playwright`, `datalad`, `jj`, `deno`, `entire`,
+`apptainer`, and `all` (expands to every extra).
+Image tags must match `^[A-Za-z0-9_][A-Za-z0-9._-]*$`.
 
 ### Build Behavior
 
@@ -376,11 +380,11 @@ When a non-`latest` tag is used, the final message points at
 
 Installs `bin/yolo` to `$HOME/.local/bin/yolo`.
 
-| Mode   | Script Exists                          | Script Missing     |
-|--------|----------------------------------------|--------------------|
-| `auto` | Prompt if differs; skip if identical   | Prompt to install  |
-| `yes`  | Overwrite                              | Install            |
-| `no`   | Skip                                   | Skip               |
+| Mode   | Script Exists                        | Script Missing    |
+|--------|--------------------------------------|-------------------|
+| `auto` | Prompt if differs; skip if identical | Prompt to install |
+| `yes`  | Overwrite                            | Install           |
+| `no`   | Skip                                 | Skip              |
 
 After install, checks if `~/.local/bin` is in `$PATH` and warns if not.
 
@@ -411,12 +415,12 @@ After install, checks if `~/.local/bin` is in `$PATH` and warns if not.
 
 ### Isolation Mechanisms
 
-| Mechanism        | Technology                       | What It Protects               |
-|------------------|----------------------------------|--------------------------------|
-| Filesystem       | Podman mount-only                | Only mounted dirs visible      |
-| User namespace   | `--userns=keep-id:uid=1000,gid=1000` | No privilege escalation   |
-| Process          | Rootless podman                  | Isolated from host processes   |
-| Network          | **None**                         | Unrestricted outbound access   |
+| Mechanism      | Technology                           | What It Protects             |
+|----------------|--------------------------------------|------------------------------|
+| Filesystem     | Podman mount-only                    | Only mounted dirs visible    |
+| User namespace | `--userns=keep-id:uid=1000,gid=1000` | No privilege escalation      |
+| Process        | Rootless podman                      | Isolated from host processes |
+| Network        | **None**                             | Unrestricted outbound access |
 
 ### Deliberate Non-restrictions
 
@@ -461,11 +465,11 @@ BATS (Bash Automated Testing System) with `bats-assert` and `bats-support`.
 
 ### Jobs
 
-| Job          | Runner                      | What It Does                                         |
-|--------------|-----------------------------|------------------------------------------------------|
-| ShellCheck   | ubuntu-latest               | Lints `setup-yolo.sh` and `bin/yolo`                 |
-| Unit Tests   | ubuntu-latest, macos-latest | Runs BATS test suite                                 |
-| Test Setup   | ubuntu-latest               | Builds image via `setup-yolo.sh`, verifies syntax    |
-| Integration  | ubuntu-latest               | Full build + `podman run --rm ... claude --help`     |
+| Job         | Runner                      | What It Does                                      |
+|-------------|-----------------------------|---------------------------------------------------|
+| ShellCheck  | ubuntu-latest               | Lints `setup-yolo.sh` and `bin/yolo`              |
+| Unit Tests  | ubuntu-latest, macos-latest | Runs BATS test suite                              |
+| Test Setup  | ubuntu-latest               | Builds image via `setup-yolo.sh`, verifies syntax |
+| Integration | ubuntu-latest               | Full build + `podman run --rm ... claude --help`  |
 
 Integration test depends on ShellCheck and Test Setup passing.

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,6 +36,8 @@ claude. If no `--` is present, all positional arguments go to claude.
 | `--anonymized-paths` | off      | Use `/claude` and `/workspace` instead of host paths         |
 | `--entrypoint=CMD`   | `claude` | Override container entrypoint                                |
 | `--entrypoint CMD`   | `claude` | Same, space-separated form                                   |
+| `--tag=TAG`          | `latest` | Image tag to run (`con-bomination-claude-code:TAG`)          |
+| `--tag TAG`          | `latest` | Same, space-separated form                                   |
 | `--worktree=MODE`    | `ask`    | Git worktree handling: `ask`, `bind`, `skip`, `error`        |
 | `--nvidia`           | off      | Enable NVIDIA GPU passthrough via CDI                        |
 | `--no-config`        | off      | Ignore all configuration files                               |
@@ -85,6 +87,11 @@ User-wide and project arrays are concatenated (user-wide first).
 | `USE_ANONYMIZED_PATHS` | `0\|1`   | `0`     | Use anonymized container paths |
 | `USE_NVIDIA`           | `0\|1`   | `0`     | Enable NVIDIA GPU passthrough  |
 | `WORKTREE_MODE`        | `string` | `ask`   | Git worktree handling mode     |
+| `YOLO_IMAGE_TAG`       | `string` | `latest` | Image tag to run              |
+
+`YOLO_IMAGE_TAG` may also be set in the environment; config files override the
+environment and `--tag` overrides both. Tags must match
+`^[A-Za-z0-9_][A-Za-z0-9._-]*$`; an invalid tag is a hard error.
 
 ### Loading Order
 
@@ -97,6 +104,7 @@ User-wide and project arrays are concatenated (user-wide first).
 7. Expand volumes via `expand_volume()` and prepend to `PODMAN_ARGS`.
 8. Prepend `YOLO_PODMAN_OPTIONS` to `PODMAN_ARGS`.
 9. Prepend `YOLO_CLAUDE_ARGS` to `CLAUDE_ARGS`.
+10. Resolve the image tag: `--tag` if given, else `YOLO_IMAGE_TAG`, else `latest`.
 
 ---
 
@@ -243,7 +251,11 @@ When `USE_NVIDIA=1`:
 
 ### Image
 
-`con-bomination-claude-code`
+`con-bomination-claude-code:$IMAGE_TAG` (tag defaults to `latest`).
+
+The tag comes from `--tag`, `YOLO_IMAGE_TAG` (config file or environment), or
+`latest`. This allows test images built by `setup-yolo.sh --tag=TAG` to be run
+side by side with the default one.
 
 ---
 
@@ -341,16 +353,24 @@ setup-yolo.sh [OPTIONS]
 | `-h`, `--help`     | —       | —                                            | Show help and exit     |
 | `--build=MODE`     | `auto`  | `auto`, `yes`, `no`                          | Image build control    |
 | `--install=MODE`   | `auto`  | `auto`, `yes`, `no`                          | Script install control |
+| `--tag=TAG`        | `latest` | tag matching `^[A-Za-z0-9_][A-Za-z0-9._-]*$` | Tag to build/check     |
 | `--packages=PKGS`  | `""`    | comma/space-separated                        | Extra apt packages     |
 | `--extras=EXTRAS`  | `""`    | `cuda`, `playwright`, `datalad`, `jj`, `deno`, `entire`, `apptainer`, `all` | Predefined extras      |
 
 ### Build Behavior
+
+Existence checks, build (`podman build -t`), and all messages use the fully
+qualified reference `con-bomination-claude-code:$IMAGE_TAG`, so each tag is
+built and checked independently.
 
 | Mode   | Image Exists | Image Missing |
 |--------|--------------|---------------|
 | `auto` | Skip         | Build         |
 | `yes`  | Rebuild      | Build         |
 | `no`   | OK           | Error         |
+
+When a non-`latest` tag is used, the final message points at
+`yolo --tag=TAG` for running the freshly built image.
 
 ### Install Behavior
 
@@ -421,7 +441,8 @@ BATS (Bash Automated Testing System) with `bats-assert` and `bats-support`.
 ### Test Coverage
 
 - Volume expansion (shorthand, options, full form, partial form)
-- All CLI flags (`--help`, `--no-config`, `--anonymized-paths`, `--nvidia`, `--entrypoint`, `--worktree`)
+- All CLI flags (`--help`, `--no-config`, `--anonymized-paths`, `--nvidia`, `--entrypoint`, `--worktree`, `--tag`)
+- Image tag resolution (default, `--tag`, `YOLO_IMAGE_TAG`, precedence, invalid tags)
 - Argument routing (with and without `--` separator)
 - Configuration loading and merging (user + project arrays, scalar overrides)
 - `XDG_CONFIG_HOME` override

--- a/bin/yolo
+++ b/bin/yolo
@@ -12,6 +12,8 @@ OPTIONS:
     --anonymized-paths   Use anonymized paths (/claude, /workspace) instead of
                          preserving host paths
     --entrypoint=CMD     Override the container entrypoint (default: claude)
+    --tag=TAG            Use image tag TAG (default: latest), i.e. run
+                         con-bomination-claude-code:TAG
     --worktree=MODE      Git worktree handling: ask, bind, skip, error
                          (default: ask)
     --nvidia             Enable NVIDIA GPU passthrough via CDI
@@ -27,6 +29,7 @@ EXAMPLES:
     yolo -v /data:/data               # Extra mount
     yolo -- "help with this code"     # Pass args to claude
     yolo --nvidia -- --resume         # GPU + claude args
+    yolo --tag=test                   # Use the :test image instead of :latest
 
 NVIDIA GPU SETUP:
     The --nvidia flag uses CDI (Container Device Interface) for GPU access.
@@ -44,6 +47,7 @@ CONFIGURATION:
     - YOLO_PODMAN_VOLUMES: array of volume mounts
     - YOLO_PODMAN_OPTIONS: array of podman options
     - YOLO_CLAUDE_ARGS: array of arguments for claude
+    - YOLO_IMAGE_TAG: image tag to run (default: latest)
     - USE_ANONYMIZED_PATHS: 0 or 1
     - USE_NVIDIA: 0 or 1
     - WORKTREE_MODE: ask, bind, skip, or error
@@ -86,6 +90,9 @@ YOLO_PODMAN_OPTIONS=(
 YOLO_CLAUDE_ARGS=(
     # "--model=claude-3-opus-20240229"
 )
+
+# Container image tag to run (built by setup-yolo.sh --tag=...)
+# YOLO_IMAGE_TAG="latest"
 
 # Default flags (0 or 1)
 # USE_ANONYMIZED_PATHS=0
@@ -172,11 +179,22 @@ expand_volume() {
     fi
 }
 
+# Validate a container image tag (podman/OCI tag grammar)
+validate_image_tag() {
+    local tag="$1"
+    if [[ ! "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
+        echo "Error: Invalid image tag: $tag" >&2
+        echo "Tags must start with an alphanumeric or _ and contain only [A-Za-z0-9._-]" >&2
+        return 1
+    fi
+}
+
 main() {
 set -e
 
 # Parse arguments: everything before -- goes to podman, everything after goes to claude
-# Also check for --anonymized-paths, --entrypoint, --worktree, --nvidia, --no-config, and --install-config flags
+# Also check for --anonymized-paths, --entrypoint, --tag, --worktree, --nvidia, --no-config,
+# and --install-config flags
 PODMAN_ARGS=()
 CLAUDE_ARGS=()
 found_separator=0
@@ -185,6 +203,12 @@ ENTRYPOINT="claude"
 WORKTREE_MODE="ask"
 USE_NVIDIA=0
 USE_CONFIG=1
+
+# Image to run. The tag may come from the environment, config files, or --tag
+# (in increasing order of precedence).
+IMAGE_NAME="con-bomination-claude-code"
+YOLO_IMAGE_TAG="${YOLO_IMAGE_TAG:-latest}"
+IMAGE_TAG_CLI=""
 
 # Initialize config arrays
 YOLO_PODMAN_VOLUMES=()
@@ -205,6 +229,16 @@ while [ $# -gt 0 ]; do
             ;;
         --entrypoint=*)
             ENTRYPOINT="${1#--entrypoint=}"
+            shift
+            ;;
+        --tag)
+            IMAGE_TAG_CLI="$2"
+            validate_image_tag "$IMAGE_TAG_CLI" || exit 1
+            shift 2
+            ;;
+        --tag=*)
+            IMAGE_TAG_CLI="${1#--tag=}"
+            validate_image_tag "$IMAGE_TAG_CLI" || exit 1
             shift
             ;;
         --worktree=*)
@@ -338,6 +372,11 @@ if [ "$USE_CONFIG" -eq 1 ]; then
     fi
 fi
 
+# --tag wins over YOLO_IMAGE_TAG from the environment or config files
+IMAGE_TAG="${IMAGE_TAG_CLI:-${YOLO_IMAGE_TAG:-latest}}"
+validate_image_tag "$IMAGE_TAG" || exit 1
+IMAGE="$IMAGE_NAME:$IMAGE_TAG"
+
 CLAUDE_HOME_DIR="$HOME/.claude"
 # must exist but might not if first start on that box
 mkdir -p "$CLAUDE_HOME_DIR"
@@ -466,7 +505,7 @@ podman run --log-driver=none -it --rm \
     -e CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS \
     "${NVIDIA_ARGS[@]}" \
     "${PODMAN_ARGS[@]}" \
-    con-bomination-claude-code \
+    "$IMAGE" \
     "${CONTAINER_CMD[@]}"
 }
 

--- a/config.example
+++ b/config.example
@@ -59,7 +59,9 @@ YOLO_CLAUDE_ARGS=(
 # DEFAULT FLAGS
 # ============================================================================
 # Set default behavior for yolo flags
-# Command line options will override these settings
+# Note: this file is sourced after the command line is parsed, so the flags
+# below override the matching command line options (YOLO_IMAGE_TAG excepted --
+# see below)
 
 # Use anonymized container paths (/claude, /workspace) instead of host paths
 # USE_ANONYMIZED_PATHS=0
@@ -83,7 +85,8 @@ YOLO_CLAUDE_ARGS=(
 # ============================================================================
 # - This file is sourced as a bash script, so you can use bash syntax
 # - Arrays can span multiple lines for readability
-# - Command line arguments always take precedence over config file
+# - Command line arguments take precedence for --tag; the scalar flags above
+#   take precedence over the command line (see the note in that section)
 # - Use --no-config flag to ignore the config file entirely
 # - Use --install-config to recreate this template
 

--- a/config.example
+++ b/config.example
@@ -71,6 +71,14 @@ YOLO_CLAUDE_ARGS=(
 # WORKTREE_MODE="ask"
 
 # ============================================================================
+# CONTAINER IMAGE
+# ============================================================================
+# Tag of the con-bomination-claude-code image to run (default: latest).
+# Build alternative tags with:  ./setup-yolo.sh --build=yes --tag=test
+# The --tag command line option overrides this value.
+# YOLO_IMAGE_TAG="latest"
+
+# ============================================================================
 # USAGE NOTES
 # ============================================================================
 # - This file is sourced as a bash script, so you can use bash syntax

--- a/setup-yolo.sh
+++ b/setup-yolo.sh
@@ -10,6 +10,7 @@ BUILD_MODE="auto"
 INSTALL_MODE="auto"
 EXTRA_PACKAGES=""
 EXTRAS=""
+IMAGE_TAG="latest"
 
 show_help() {
     cat << EOF
@@ -27,6 +28,9 @@ OPTIONS:
                             auto - install if missing or prompt if exists and differs
                             yes  - always install/overwrite without prompting
                             no   - skip installation
+    --tag=TAG               Tag to build/check the image with (default: latest)
+                            Use to keep test images alongside the default one,
+                            then run them with 'yolo --tag=TAG'
     --packages=PKGS         Extra apt packages to install in the container image
                             (comma or space-separated, requires rebuild)
     --extras=EXTRAS         Predefined extras to include (comma-separated):
@@ -68,6 +72,11 @@ EXAMPLES:
     # Build with all extras
     ./setup-yolo.sh --build=yes --extras=all
 
+    # Build a throw-away test image without touching :latest or ~/.local/bin/yolo
+    ./setup-yolo.sh --build=yes --install=no --tag=test
+    # ... then use it with:
+    #   yolo --tag=test
+
 EOF
     exit 0
 }
@@ -90,6 +99,15 @@ while [[ $# -gt 0 ]]; do
             INSTALL_MODE="${1#*=}"
             if [[ ! "$INSTALL_MODE" =~ ^(auto|yes|no)$ ]]; then
                 echo "Error: --install must be one of: auto, yes, no"
+                exit 1
+            fi
+            shift
+            ;;
+        --tag=*)
+            IMAGE_TAG="${1#*=}"
+            if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
+                echo "Error: Invalid image tag: $IMAGE_TAG"
+                echo "Tags must start with an alphanumeric or _ and contain only [A-Za-z0-9._-]"
                 exit 1
             fi
             shift
@@ -123,27 +141,30 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Fully qualified image reference to build/check
+IMAGE="$IMAGE_NAME:$IMAGE_TAG"
+
 echo "🚀 Claude Code YOLO Mode Setup"
 echo "================================"
 echo
 
 # Handle image building based on BUILD_MODE
 IMAGE_EXISTS=false
-if podman image exists "$IMAGE_NAME" 2>/dev/null; then
+if podman image exists "$IMAGE" 2>/dev/null; then
     IMAGE_EXISTS=true
 fi
 
 if [ "$BUILD_MODE" = "no" ]; then
     if [ "$IMAGE_EXISTS" = false ]; then
-        echo "Error: Image '$IMAGE_NAME' does not exist and --build=no was specified"
+        echo "Error: Image '$IMAGE' does not exist and --build=no was specified"
         exit 1
     fi
     echo "✓ Skipping build (--build=no specified)"
 elif [ "$BUILD_MODE" = "yes" ] || [ "$IMAGE_EXISTS" = false ]; then
     if [ "$BUILD_MODE" = "yes" ]; then
-        echo "Rebuilding container image '$IMAGE_NAME'..."
+        echo "Rebuilding container image '$IMAGE'..."
     else
-        echo "Building container image '$IMAGE_NAME'..."
+        echo "Building container image '$IMAGE'..."
     fi
     if [ -n "$EXTRA_PACKAGES" ]; then
         echo "Extra packages: $EXTRA_PACKAGES"
@@ -163,13 +184,13 @@ elif [ "$BUILD_MODE" = "yes" ] || [ "$IMAGE_EXISTS" = false ]; then
     for extra in ${EXTRAS//,/ }; do
         BUILD_ARGS+=(--build-arg "EXTRA_$(echo "$extra" | tr '[:lower:]' '[:upper:]')=1")
     done
-    podman build "${BUILD_ARGS[@]}" -t "$IMAGE_NAME" "$DOCKERFILE_DIR"
+    podman build "${BUILD_ARGS[@]}" -t "$IMAGE" "$DOCKERFILE_DIR"
 
     echo
     echo "✓ Container image built successfully"
 else
     # BUILD_MODE=auto and image exists
-    echo "✓ Container image '$IMAGE_NAME' already exists"
+    echo "✓ Container image '$IMAGE' already exists"
 fi
 
 echo
@@ -237,6 +258,12 @@ fi
 if [ "$SHOULD_INSTALL" = false ]; then
     echo
     echo "Setup complete! Container image is ready."
+    if [ "$IMAGE_TAG" != "latest" ]; then
+        echo
+        echo "Run it with an already installed yolo script:"
+        echo "  yolo --tag=$IMAGE_TAG"
+        echo
+    fi
     echo "Run manually with preserved host paths (default):"
     echo "  podman run -it --rm --userns=keep-id \\"
     echo "    -v ~/.claude:~/.claude:Z \\"
@@ -245,7 +272,7 @@ if [ "$SHOULD_INSTALL" = false ]; then
     echo "    -w \"\$(pwd)\" \\"
     echo "    -e CLAUDE_CONFIG_DIR=~/.claude \\"
     echo "    -e GIT_CONFIG_GLOBAL=/tmp/.gitconfig \\"
-    echo "    $IMAGE_NAME \\"
+    echo "    $IMAGE \\"
     echo "    claude --dangerously-skip-permissions"
     echo
     echo "Or with anonymized paths (/claude, /workspace):"
@@ -256,11 +283,11 @@ if [ "$SHOULD_INSTALL" = false ]; then
     echo "    -w /workspace \\"
     echo "    -e CLAUDE_CONFIG_DIR=/claude \\"
     echo "    -e GIT_CONFIG_GLOBAL=/tmp/.gitconfig \\"
-    echo "    $IMAGE_NAME \\"
+    echo "    $IMAGE \\"
     echo "    claude --dangerously-skip-permissions"
     echo
     echo "Pass extra podman options and claude arguments like:"
-    echo "  podman run ... [podman-options] $IMAGE_NAME claude [claude-args]"
+    echo "  podman run ... [podman-options] $IMAGE claude [claude-args]"
     exit 0
 fi
 
@@ -294,7 +321,11 @@ if [ "$SHOULD_INSTALL" = true ]; then
     echo "To start using YOLO mode:"
     echo "  1. Make sure ~/.local/bin is in your PATH (restart shell if needed)"
     echo "  2. Navigate to any project directory"
-    echo "  3. Run: yolo"
+    if [ "$IMAGE_TAG" = "latest" ]; then
+        echo "  3. Run: yolo"
+    else
+        echo "  3. Run: yolo --tag=$IMAGE_TAG  (image was built as '$IMAGE')"
+    fi
     echo
     echo "By default, yolo preserves original host paths for session compatibility."
     echo "Use --anonymized-paths flag for anonymized paths (/claude, /workspace):"

--- a/tests/yolo.bats
+++ b/tests/yolo.bats
@@ -73,6 +73,31 @@ EOF
     refute_podman_arg "--dangerously-skip-permissions"
 }
 
+@test "--tag: default image reference is :latest" {
+    run_yolo
+    assert_success
+    podman_args_contain "con-bomination-claude-code:latest"
+}
+
+@test "--tag=TAG: image reference uses the given tag" {
+    run_yolo --tag=test
+    assert_success
+    podman_args_contain "con-bomination-claude-code:test"
+    refute_podman_arg "con-bomination-claude-code:latest"
+}
+
+@test "--tag TAG: space-separated form works" {
+    run_yolo --tag test
+    assert_success
+    podman_args_contain "con-bomination-claude-code:test"
+}
+
+@test "--tag: invalid tag exits with error" {
+    run_yolo --tag="bad:tag"
+    assert_failure
+    assert_output --partial "Invalid image tag"
+}
+
 @test "--worktree=invalid: exits with error" {
     run_yolo --worktree=invalid
     assert_failure
@@ -191,6 +216,47 @@ EOF
     run_yolo
     assert_success
     podman_args_contain "--verbose"
+}
+
+@test "config: YOLO_IMAGE_TAG selects the image tag" {
+    write_user_config << 'EOF'
+YOLO_IMAGE_TAG="from-config"
+EOF
+    run_yolo
+    assert_success
+    podman_args_contain "con-bomination-claude-code:from-config"
+}
+
+@test "config: project YOLO_IMAGE_TAG overrides user-wide one" {
+    write_user_config << 'EOF'
+YOLO_IMAGE_TAG="from-user"
+EOF
+    write_project_config << 'EOF'
+YOLO_IMAGE_TAG="from-project"
+EOF
+    run_yolo
+    assert_success
+    podman_args_contain "con-bomination-claude-code:from-project"
+    refute_podman_arg "con-bomination-claude-code:from-user"
+}
+
+@test "config: --tag overrides YOLO_IMAGE_TAG from config" {
+    write_project_config << 'EOF'
+YOLO_IMAGE_TAG="from-config"
+EOF
+    run_yolo --tag=from-cli
+    assert_success
+    podman_args_contain "con-bomination-claude-code:from-cli"
+    refute_podman_arg "con-bomination-claude-code:from-config"
+}
+
+@test "config: --no-config ignores YOLO_IMAGE_TAG from config files" {
+    write_project_config << 'EOF'
+YOLO_IMAGE_TAG="from-config"
+EOF
+    run_yolo --no-config
+    assert_success
+    podman_args_contain "con-bomination-claude-code:latest"
 }
 
 # ── Environment variables & container setup ───────────────────────


### PR DESCRIPTION
The image was always built and run as `con-bomination-claude-code`
(implicitly `:latest`), so testing an image variant meant clobbering the image
used for everyday work. Both entry points now take a tag.

## `setup-yolo.sh --tag=TAG` (default `latest`)

The existence check, `podman build -t`, and every message use the fully
qualified `con-bomination-claude-code:TAG`, so each tag is built and checked
independently. A non-`latest` build ends with a hint pointing at `yolo --tag=TAG`.

## `yolo --tag=TAG` / `--tag TAG` (default `latest`)

Runs `con-bomination-claude-code:TAG`. The tag can also come from
`YOLO_IMAGE_TAG` in the user-wide/project config or the environment; precedence
is env < user config < project config < `--tag`.

Note that the CLI flag explicitly wins here. The existing scalars
(`USE_NVIDIA`, `WORKTREE_MODE`, …) are in fact overridden by config because the
config files are sourced after argument parsing, contrary to what SPEC.md
claims. That pre-existing quirk is left alone rather than widening this PR.

Both scripts reject tags that don't match the OCI grammar
`^[A-Za-z0-9_][A-Za-z0-9._-]*$`.

Typical test flow:

```bash
./setup-yolo.sh --build=yes --install=no --tag=test   # builds :test, :latest untouched
yolo --tag=test                                       # run it
yolo                                                  # back to :latest
```

## Docs and tests

`SPEC.md`, `README.md` (new "Image Tags" section), `config.example`, both
`--help` texts, and the config template embedded in `bin/yolo` are updated
together. The second commit is a formatting-only pass making every `SPEC.md`
table line up: the new rows didn't fit the existing columns, and several
pre-existing tables were ragged as well. The only content change there is in
the `setup-yolo.sh` flags table, where two overlong `Values` cells (the tag
regex and the `--extras` list) move into a sentence below the table.

Eight new BATS cases cover the default tag, `--tag=`/`--tag `, invalid tags,
`YOLO_IMAGE_TAG` from user and project config, CLI-over-config precedence, and
`--no-config`. The full suite (34 tests) and shellcheck pass locally; the
`setup-yolo.sh` build/no-build/invalid-tag paths were exercised against a mock
podman. CI gains `--tag` coverage cheaply by re-tagging the already built image
instead of building a second one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDHHvaq5fbcD4yLWLo2e4E)_